### PR TITLE
Implement caching and history, disable pages

### DIFF
--- a/app_pages/combined_analysis.py
+++ b/app_pages/combined_analysis.py
@@ -10,34 +10,89 @@ from app_pages.price_change_by_label import (
     get_mappings,
     compute_period_metrics as label_compute,
 )
-from utils import update_shared_range
+from utils import update_shared_range, safe_rerun, short_time_range
+from query_history import add_entry, get_history
+from result_cache import load_cached, save_cached
 
 
 def render_combined_page():
     st.title("综合分析")
+
+    user = st.session_state.get("username", "default")
+    history = get_history("combined_analysis", user)
+
+    if "combo_load_params" in st.session_state:
+        params = st.session_state.pop("combo_load_params")
+        st.session_state["combo_start_date"] = date.fromisoformat(params["start_date"])
+        st.session_state["combo_start_time"] = time.fromisoformat(params["start_time"])
+        st.session_state["combo_end_date"] = date.fromisoformat(params["end_date"])
+        st.session_state["combo_end_time"] = time.fromisoformat(params["end_time"])
+        st.session_state["combo_bars"] = params.get("bars", 4)
+        st.session_state["combo_factor"] = params.get("factor", 100.0)
+        update_shared_range(
+            st.session_state["combo_start_date"],
+            st.session_state["combo_start_time"],
+            st.session_state["combo_end_date"],
+            st.session_state["combo_end_time"],
+        )
+
+    with st.sidebar.expander("历史记录", expanded=False):
+        if history:
+            labels = [
+                short_time_range(
+                    h["params"]["start_date"],
+                    h["params"]["start_time"],
+                    h["params"]["end_date"],
+                    h["params"]["end_time"],
+                )
+                for h in history
+            ]
+            idx = st.selectbox(
+                "选择记录",
+                range(len(history)),
+                format_func=lambda i: labels[i],
+                key="combo_hist_select",
+            )
+            if st.button("载入历史", key="combo_hist_load"):
+                st.session_state["combo_load_params"] = history[idx]["params"]
+                safe_rerun()
+        else:
+            st.write("暂无历史记录")
 
     # 日期时间输入，只需填写一次
     col1, col2 = st.columns(2)
     with col1:
         start_date = st.date_input(
             "开始日期",
-            st.session_state.get("range_start_date", date.today() - timedelta(days=7)),
+            st.session_state.get(
+                "combo_start_date",
+                st.session_state.get("range_start_date", date.today() - timedelta(days=7)),
+            ),
             key="combo_start_date",
         )
         start_time = st.time_input(
             "开始时间",
-            st.session_state.get("range_start_time", time(0, 0)),
+            st.session_state.get(
+                "combo_start_time",
+                st.session_state.get("range_start_time", time(0, 0)),
+            ),
             key="combo_start_time",
         )
     with col2:
         end_date = st.date_input(
             "结束日期",
-            st.session_state.get("range_end_date", date.today()),
+            st.session_state.get(
+                "combo_end_date",
+                st.session_state.get("range_end_date", date.today()),
+            ),
             key="combo_end_date",
         )
         end_time = st.time_input(
             "结束时间",
-            st.session_state.get("range_end_time", time(23, 59)),
+            st.session_state.get(
+                "combo_end_time",
+                st.session_state.get("range_end_time", time(23, 59)),
+            ),
             key="combo_end_time",
         )
 
@@ -54,131 +109,187 @@ def render_combined_page():
     st.subheader("强势标的筛选")
     run_sa = st.button("计算强势标的", key="combo_sa_btn")
     if run_sa or run_all:
-        with engine_ohlcv.connect() as conn:
-            symbols = [
-                row[0]
-                for row in conn.execute(text("SELECT DISTINCT symbol FROM ohlcv"))
-            ]
-            result = conn.execute(text("SELECT instrument_id, labels FROM instruments"))
-            labels_map = {instr_id: labels for instr_id, labels in result}
-
-        records = []
-        for symbol in symbols:
-            try:
-                m = compute_period_metrics(symbol, start_ts, end_ts)
-            except ValueError:
-                continue
-            m["symbol"] = symbol
-            records.append(m)
-
-        if not records:
-            st.warning("该区间内无数据")
-        else:
-            df = pd.DataFrame(records)
-            df["max_close_dt"] = (
-                pd.to_datetime(df["max_close_dt"], unit="ms", utc=True)
-                .dt.tz_convert("Asia/Shanghai")
-                .dt.strftime("%m-%d %H:%M")
-            )
-            df["min_close_dt"] = (
-                pd.to_datetime(df["min_close_dt"], unit="ms", utc=True)
-                .dt.tz_convert("Asia/Shanghai")
-                .dt.strftime("%m-%d %H:%M")
-            )
-            df["period_return (%)"] = (df["period_return"] * 100).round(2)
-            df["drawdown (%)"] = (df["drawdown"] * 100).round(2)
-            df["标签"] = df["symbol"].map(
-                lambda s: "，".join(labels_map.get(s, [])) if labels_map.get(s) else ""
-            )
-            df = (
-                df[
-                    [
-                        "标签",
-                        "symbol",
-                        "first_close",
-                        "last_close",
-                        "period_return (%)",
-                        "max_close",
-                        "max_close_dt",
-                        "min_close",
-                        "min_close_dt",
-                        "drawdown (%)",
-                    ]
+        sa_params = {
+            "start_date": start_date.isoformat(),
+            "start_time": start_time.isoformat(),
+            "end_date": end_date.isoformat(),
+            "end_time": end_time.isoformat(),
+        }
+        sa_cache_id, df = load_cached("strong_assets", sa_params)
+        if df is None:
+            with engine_ohlcv.connect() as conn:
+                symbols = [
+                    row[0]
+                    for row in conn.execute(text("SELECT DISTINCT symbol FROM ohlcv"))
                 ]
-                .sort_values("period_return (%)", ascending=False)
-                .reset_index(drop=True)
-            )
-            df = df.rename(
-                columns={
-                    "symbol": "代币名字",
-                    "first_close": "时间1",
-                    "last_close": "时间2",
-                    "period_return (%)": "期间收益",
-                    "max_close": "期间最高价",
-                    "max_close_dt": "最高价时间",
-                    "min_close": "期间最低价",
-                    "min_close_dt": "最低价时间",
-                    "drawdown (%)": "最大回撤",
-                }
-            )
-            st.dataframe(df, use_container_width=True)
+                result = conn.execute(text("SELECT instrument_id, labels FROM instruments"))
+                labels_map = {instr_id: labels for instr_id, labels in result}
+
+            records = []
+            for symbol in symbols:
+                try:
+                    m = compute_period_metrics(symbol, start_ts, end_ts)
+                except ValueError:
+                    continue
+                m["symbol"] = symbol
+                records.append(m)
+
+            if not records:
+                st.warning("该区间内无数据")
+                return
+
+            df = pd.DataFrame(records)
+            save_cached("strong_assets", sa_params, df)
+        else:
+            with engine_ohlcv.connect() as conn:
+                result = conn.execute(text("SELECT instrument_id, labels FROM instruments"))
+                labels_map = {instr_id: labels for instr_id, labels in result}
+
+        add_entry(
+            "combined_analysis",
+            user,
+            {
+                "start_date": start_date.isoformat(),
+                "start_time": start_time.isoformat(),
+                "end_date": end_date.isoformat(),
+                "end_time": end_time.isoformat(),
+                "bars": bars,
+                "factor": factor,
+            },
+            {"sa_id": sa_cache_id},
+        )
+        df["max_close_dt"] = (
+            pd.to_datetime(df["max_close_dt"], unit="ms", utc=True)
+            .dt.tz_convert("Asia/Shanghai")
+            .dt.strftime("%m-%d %H:%M")
+        )
+        df["min_close_dt"] = (
+            pd.to_datetime(df["min_close_dt"], unit="ms", utc=True)
+            .dt.tz_convert("Asia/Shanghai")
+            .dt.strftime("%m-%d %H:%M")
+        )
+        df["period_return (%)"] = (df["period_return"] * 100).round(2)
+        df["drawdown (%)"] = (df["drawdown"] * 100).round(2)
+        df["标签"] = df["symbol"].map(
+            lambda s: "，".join(labels_map.get(s, [])) if labels_map.get(s) else ""
+        )
+        df = (
+            df[
+                [
+                    "标签",
+                    "symbol",
+                    "first_close",
+                    "last_close",
+                    "period_return (%)",
+                    "max_close",
+                    "max_close_dt",
+                    "min_close",
+                    "min_close_dt",
+                    "drawdown (%)",
+                ]
+            ]
+            .sort_values("period_return (%)", ascending=False)
+            .reset_index(drop=True)
+        )
+        df = df.rename(
+            columns={
+                "symbol": "代币名字",
+                "first_close": "时间1",
+                "last_close": "时间2",
+                "period_return (%)": "期间收益",
+                "max_close": "期间最高价",
+                "max_close_dt": "最高价时间",
+                "min_close": "期间最低价",
+                "min_close_dt": "最低价时间",
+                "drawdown (%)": "最大回撤",
+            }
+        )
+        st.dataframe(df, use_container_width=True)
 
     st.subheader("底部抬升筛选")
     bars = st.number_input(
-        "± N 根 K 线 (bars)", min_value=1, value=4, step=1, key="combo_bars"
+        "± N 根 K 线 (bars)", min_value=1, value=st.session_state.get("combo_bars", 4), step=1, key="combo_bars"
     )
     factor = st.number_input(
-        "放大因子 (factor)", min_value=1.0, value=100.0, step=1.0, key="combo_factor"
+        "放大因子 (factor)", min_value=1.0, value=float(st.session_state.get("combo_factor", 100.0)), step=1.0, key="combo_factor"
     )
     run_bl = st.button("运行底部抬升分析", key="combo_bl_btn")
     if run_bl or run_all:
-        df = analyze_bottom_lift(start_dt, end_dt, bars=bars, factor=factor)
-        if df.empty:
-            st.warning("无符合条件的数据")
-        else:
-            with engine_ohlcv.connect() as conn:
-                result = conn.execute(
-                    text("SELECT instrument_id, labels FROM instruments")
-                )
-                labels_map = {instr_id: labels for instr_id, labels in result}
-            df["标签"] = df.index.map(
-                lambda s: "，".join(labels_map.get(s, [])) if labels_map.get(s) else ""
-            )
-            df["L1_time"] = (
-                pd.to_datetime(df["L1_time"], utc=True)
-                .dt.tz_convert("Asia/Shanghai")
-                .dt.strftime("%m-%d %H:%M")
-            )
-            df["L2_time"] = (
-                pd.to_datetime(df["L2_time"], utc=True)
-                .dt.tz_convert("Asia/Shanghai")
-                .dt.strftime("%m-%d %H:%M")
-            )
-            df = df.reset_index()
-            df = df[
-                ["标签", "symbol", "L1_time", "L1_low", "L2_time", "L2_low", "slope"]
-            ]
-            df = df.rename(columns={"symbol": "代币名字"})
-            df = df.sort_values("slope", ascending=False).reset_index(drop=True)
-            st.dataframe(df, use_container_width=True)
+        bl_params = {
+            "t1": start_dt.isoformat(),
+            "t2": end_dt.isoformat(),
+            "bars": bars,
+            "factor": factor,
+        }
+        bl_cache_id, df = load_cached("bottom_lift", bl_params)
+        if df is None:
+            df = analyze_bottom_lift(start_dt, end_dt, bars=bars, factor=factor)
+            if df.empty:
+                st.warning("无符合条件的数据")
+                return
+            save_cached("bottom_lift", bl_params, df)
+
+        add_entry(
+            "combined_analysis",
+            user,
+            {
+                "start_date": start_date.isoformat(),
+                "start_time": start_time.isoformat(),
+                "end_date": end_date.isoformat(),
+                "end_time": end_time.isoformat(),
+                "bars": bars,
+                "factor": factor,
+            },
+            {"bl_id": bl_cache_id},
+        )
+
+        with engine_ohlcv.connect() as conn:
+            result = conn.execute(text("SELECT instrument_id, labels FROM instruments"))
+            labels_map = {instr_id: labels for instr_id, labels in result}
+        df["标签"] = df.index.map(
+            lambda s: "，".join(labels_map.get(s, [])) if labels_map.get(s) else ""
+        )
+        df["L1_time"] = (
+            pd.to_datetime(df["L1_time"], utc=True)
+            .dt.tz_convert("Asia/Shanghai")
+            .dt.strftime("%m-%d %H:%M")
+        )
+        df["L2_time"] = (
+            pd.to_datetime(df["L2_time"], utc=True)
+            .dt.tz_convert("Asia/Shanghai")
+            .dt.strftime("%m-%d %H:%M")
+        )
+        df = df.reset_index()
+        df = df[["标签", "symbol", "L1_time", "L1_low", "L2_time", "L2_low", "slope"]]
+        df = df.rename(columns={"symbol": "代币名字"})
+        df = df.sort_values("slope", ascending=False).reset_index(drop=True)
+        st.dataframe(df, use_container_width=True)
 
     st.subheader("标签化涨跌幅")
     run_label = st.button("计算标签涨跌幅", key="combo_label_btn")
     if run_label or run_all:
-        df_map = get_mappings()
-        symbols = df_map["symbol"].unique()
-        recs = []
-        for sym in symbols:
-            ret, _ = label_compute(sym, start_ts, end_ts)
-            if ret is None:
-                continue
-            lbls = df_map.loc[df_map["symbol"] == sym, "label"]
-            for lbl in lbls:
-                recs.append({"symbol": sym, "label": lbl, "return": ret})
-        df = pd.DataFrame(recs)
-        if df.empty:
-            st.warning("无有效数据")
-        else:
+        label_params = {
+            "start_date": start_date.isoformat(),
+            "start_time": start_time.isoformat(),
+            "end_date": end_date.isoformat(),
+            "end_time": end_time.isoformat(),
+        }
+        label_cache_id, df = load_cached("price_change_by_label", label_params)
+        if df is None:
+            df_map = get_mappings()
+            symbols = df_map["symbol"].unique()
+            recs = []
+            for sym in symbols:
+                ret, _ = label_compute(sym, start_ts, end_ts)
+                if ret is None:
+                    continue
+                lbls = df_map.loc[df_map["symbol"] == sym, "label"]
+                for lbl in lbls:
+                    recs.append({"symbol": sym, "label": lbl, "return": ret})
+            df = pd.DataFrame(recs)
+            if df.empty:
+                st.warning("无有效数据")
+                return
             rmin, rmax = df["return"].min(), df["return"].max()
             low = (rmin * 100 // 5) * 5 / 100
             high = (rmax * 100 + 4) // 5 * 5 / 100
@@ -186,32 +297,52 @@ def render_combined_page():
             bucket_labels = [
                 f"{int(l*100)}%~{int(u*100)}%" for l, u in zip(bins[:-1], bins[1:])
             ]
-            df["bucket"] = pd.cut(
-                df["return"], bins=bins, labels=bucket_labels, include_lowest=True
-            )
-            grp = (
-                df.groupby(["label", "bucket"])["symbol"]
-                .nunique()
-                .reset_index(name="count")
-            )
-            pivot = (
-                grp.pivot(index="label", columns="bucket", values="count")
-                .fillna(0)
-                .astype(int)
-            )
-            pivot = pivot.loc[:, pivot.sum(axis=0) > 0]
-            styled = pivot.style.format(lambda v: "" if v == 0 else v)
-            st.dataframe(styled, use_container_width=True)
-            for bucket in pivot.columns[::-1]:
-                df_b = df[df["bucket"] == bucket]
-                if df_b.empty:
-                    continue
-                with st.expander(f"{bucket} （共 {len(df_b)} 条）"):
-                    df_show = df_b[["symbol", "label", "return"]].copy()
-                    df_show["return"] = df_show["return"].map("{:.2%}".format)
-                    st.dataframe(
-                        df_show.sort_values(
-                            ["return", "symbol"], ascending=[False, True]
-                        ),
-                        use_container_width=True,
-                    )
+            df["bucket"] = pd.cut(df["return"], bins=bins, labels=bucket_labels, include_lowest=True)
+            save_cached("price_change_by_label", label_params, df)
+
+        add_entry(
+            "combined_analysis",
+            user,
+            {
+                "start_date": start_date.isoformat(),
+                "start_time": start_time.isoformat(),
+                "end_date": end_date.isoformat(),
+                "end_time": end_time.isoformat(),
+                "bars": bars,
+                "factor": factor,
+            },
+            {"label_id": label_cache_id},
+        )
+
+        rmin, rmax = df["return"].min(), df["return"].max()
+        low = (rmin * 100 // 5) * 5 / 100
+        high = (rmax * 100 + 4) // 5 * 5 / 100
+        bins = np.arange(low, high + 0.0001, 0.05)
+        bucket_labels = [
+            f"{int(l*100)}%~{int(u*100)}%" for l, u in zip(bins[:-1], bins[1:])
+        ]
+        df["bucket"] = pd.cut(df["return"], bins=bins, labels=bucket_labels, include_lowest=True)
+        grp = (
+            df.groupby(["label", "bucket"])["symbol"]
+            .nunique()
+            .reset_index(name="count")
+        )
+        pivot = (
+            grp.pivot(index="label", columns="bucket", values="count")
+            .fillna(0)
+            .astype(int)
+        )
+        pivot = pivot.loc[:, pivot.sum(axis=0) > 0]
+        styled = pivot.style.format(lambda v: "" if v == 0 else v)
+        st.dataframe(styled, use_container_width=True)
+        for bucket in pivot.columns[::-1]:
+            df_b = df[df["bucket"] == bucket]
+            if df_b.empty:
+                continue
+            with st.expander(f"{bucket} （共 {len(df_b)} 条）"):
+                df_show = df_b[["symbol", "label", "return"]].copy()
+                df_show["return"] = df_show["return"].map("{:.2%}".format)
+                st.dataframe(
+                    df_show.sort_values(["return", "symbol"], ascending=[False, True]),
+                    use_container_width=True,
+                )

--- a/app_pages/price_change_by_label.py
+++ b/app_pages/price_change_by_label.py
@@ -8,9 +8,11 @@ import numpy as np
 from datetime import datetime, date, time, timedelta, timezone
 from sqlalchemy import text
 from db import engine_ohlcv
-from config import TZ_NAME
 import psycopg2
 from dotenv import load_dotenv
+from utils import safe_rerun, short_time_range
+from query_history import add_entry, get_history
+from result_cache import load_cached, save_cached
 
 # —— 1. 读取环境 & 配置 ——
 load_dotenv()
@@ -74,22 +76,71 @@ def compute_period_metrics(symbol, start_ts, end_ts):
 def render_price_change_by_label():
     st.title("📊 按涨跌幅区间 分析 Label")
 
+    user = st.session_state.get("username", "default")
+    history = get_history("price_change_by_label", user)
+
+    if "pcl_load_params" in st.session_state:
+        params = st.session_state.pop("pcl_load_params")
+        sd = date.fromisoformat(params["start_date"])
+        stime = time.fromisoformat(params["start_time"])
+        ed = date.fromisoformat(params["end_date"])
+        etime = time.fromisoformat(params["end_time"])
+        preset = params.get("preset", True)
+    else:
+        preset = True
+        sd = None
+        stime = None
+        ed = None
+        etime = None
+
+    with st.sidebar.expander("历史记录", expanded=False):
+        if history:
+            labels = [
+                short_time_range(
+                    h["params"]["start_date"],
+                    h["params"]["start_time"],
+                    h["params"]["end_date"],
+                    h["params"]["end_time"],
+                )
+                for h in history
+            ]
+            idx = st.selectbox(
+                "选择记录",
+                range(len(history)),
+                format_func=lambda i: labels[i],
+                key="pcl_hist_select",
+            )
+            if st.button("载入历史", key="pcl_hist_load"):
+                st.session_state["pcl_load_params"] = history[idx]["params"]
+                safe_rerun()
+        else:
+            st.write("暂无历史记录")
+
     # —— 2. 时间区间控件 —— 
     now = datetime.now(timezone.utc)
     st.markdown("#### 请选择时间区间")
     c1, c2 = st.columns(2)
     with c1:
-        sd = st.date_input("开始日期", now.date() - timedelta(hours=4))
-        stime = st.time_input("开始时间", time(now.hour, now.minute))
+        sd = st.date_input(
+            "开始日期",
+            sd or (now.date() - timedelta(hours=4)),
+        )
+        stime = st.time_input(
+            "开始时间",
+            stime or time(now.hour, now.minute),
+        )
     with c2:
-        ed = st.date_input("结束日期", now.date())
-        etime = st.time_input("结束时间", time(now.hour, now.minute))
+        ed = st.date_input("结束日期", ed or now.date())
+        etime = st.time_input(
+            "结束时间",
+            etime or time(now.hour, now.minute),
+        )
     start_dt = datetime(sd.year, sd.month, sd.day, stime.hour, stime.minute, tzinfo=timezone.utc)
     end_dt   = datetime(ed.year, ed.month, ed.day, etime.hour, etime.minute, tzinfo=timezone.utc)
     start_custom_ts = int(start_dt.timestamp()*1000)
     end_custom_ts   = int(end_dt.timestamp()*1000)
 
-    preset = st.checkbox("使用 4 小时 窗口", value=True)
+    preset = st.checkbox("使用 4 小时 窗口", value=preset)
     if preset:
         start_ts = int((now - timedelta(hours=4)).timestamp()*1000)
         end_ts   = int(now.timestamp()*1000)
@@ -97,30 +148,41 @@ def render_price_change_by_label():
         start_ts = start_custom_ts
         end_ts   = end_custom_ts
 
-    # —— 3. 读取映射 & 计算 —— 
-    df_map = get_mappings()
-    symbols = df_map['symbol'].unique()
-    recs = []
-    for sym in symbols:
-        ret, _ = compute_period_metrics(sym, start_ts, end_ts)
-        if ret is None: continue
-        lbls = df_map.loc[df_map['symbol']==sym, 'label']
-        for lbl in lbls:
-            recs.append({'symbol':sym, 'label':lbl, 'return':ret})
-    df = pd.DataFrame(recs)
-    if df.empty:
-        st.warning("无有效数据")
-        return
+    params = {
+        "start_date": sd.isoformat(),
+        "start_time": stime.isoformat(),
+        "end_date": ed.isoformat(),
+        "end_time": etime.isoformat(),
+        "preset": preset,
+    }
+    cache_id, df = load_cached("price_change_by_label", params)
+    if df is None:
+        # —— 3. 读取映射 & 计算 ——
+        df_map = get_mappings()
+        symbols = df_map['symbol'].unique()
+        recs = []
+        for sym in symbols:
+            ret, _ = compute_period_metrics(sym, start_ts, end_ts)
+            if ret is None:
+                continue
+            lbls = df_map.loc[df_map['symbol'] == sym, 'label']
+            for lbl in lbls:
+                recs.append({'symbol': sym, 'label': lbl, 'return': ret})
+        df = pd.DataFrame(recs)
+        if df.empty:
+            st.warning("无有效数据")
+            return
+        # —— 4. 构建桶区间 & 分配 ——
+        rmin, rmax = df['return'].min(), df['return'].max()
+        low = math.floor(rmin * 100 / 5) * 5 / 100
+        high = math.ceil(rmax * 100 / 5) * 5 / 100
+        bins = np.arange(low, high + 0.0001, 0.05)
+        bucket_labels = [f"{int(l*100)}%~{int(u*100)}%" for l, u in zip(bins[:-1], bins[1:])]
+        df['bucket'] = pd.cut(df['return'], bins=bins, labels=bucket_labels, include_lowest=True)
+        save_cached("price_change_by_label", params, df)
+    add_entry("price_change_by_label", user, params, {"id": cache_id})
 
-    # —— 4. 构建桶区间 & 分配 —— 
-    rmin, rmax = df['return'].min(), df['return'].max()
-    low = math.floor(rmin*100/5)*5/100
-    high= math.ceil(rmax*100/5)*5/100
-    bins = np.arange(low, high+0.0001, 0.05)
-    bucket_labels = [f"{int(l*100)}%~{int(u*100)}%" for l,u in zip(bins[:-1],bins[1:])]
-    df['bucket'] = pd.cut(df['return'], bins=bins, labels=bucket_labels, include_lowest=True)
-
-    # —— 5. 统计透视表 —— 
+    # —— 5. 统计透视表 ——
     grp = df.groupby(['label','bucket'])['symbol'].nunique().reset_index(name='count')
     pivot = grp.pivot(index='label', columns='bucket', values='count').fillna(0).astype(int)
 

--- a/query_history.py
+++ b/query_history.py
@@ -1,7 +1,7 @@
 import json
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 FILE_PATH = Path("data/query_history.json")
 
@@ -22,8 +22,11 @@ def _save(history: Dict[str, Dict[str, List[dict]]]) -> None:
     FILE_PATH.write_text(json.dumps(history, ensure_ascii=False, indent=2), encoding="utf-8")
 
 
-def add_entry(page: str, user: str, params: Dict[str, Any]) -> None:
-    """Add a history entry for a page and user."""
+def add_entry(page: str, user: str, params: Dict[str, Any], extra: Optional[Dict[str, Any]] = None) -> None:
+    """Add a history entry for a page and user.
+
+    ``extra`` can store additional metadata such as cached result ids.
+    """
     history = _load()
     if not isinstance(history, dict):
         history = {}
@@ -37,6 +40,7 @@ def add_entry(page: str, user: str, params: Dict[str, Any]) -> None:
         user_hist = []
     user_hist.insert(0, {
         "params": params,
+        "extra": extra or {},
         "time": datetime.now().isoformat(timespec="seconds")
     })
     page_hist[user] = user_hist[:20]

--- a/result_cache.py
+++ b/result_cache.py
@@ -1,0 +1,53 @@
+import json
+import hashlib
+from pathlib import Path
+from typing import Any, Dict, Tuple, Optional
+
+import pandas as pd
+
+CACHE_DIR = Path("data/cache")
+
+
+def _hash_params(params: Dict[str, Any]) -> str:
+    """Return a stable hash for a dict of parameters."""
+    serial = json.dumps(params, sort_keys=True, ensure_ascii=False)
+    return hashlib.md5(serial.encode("utf-8")).hexdigest()
+
+
+def load_cached(page: str, params: Dict[str, Any]) -> Tuple[str, Optional[pd.DataFrame]]:
+    """Load cached DataFrame for page/params.
+
+    Returns (cache_id, df or None).
+    """
+    cache_id = _hash_params(params)
+    path = CACHE_DIR / page / f"{cache_id}.csv"
+    if path.exists():
+        try:
+            df = pd.read_csv(path)
+            return cache_id, df
+        except Exception:
+            pass
+    return cache_id, None
+
+
+def save_cached(page: str, params: Dict[str, Any], df: pd.DataFrame) -> str:
+    """Save DataFrame to cache and return cache_id."""
+    cache_id = _hash_params(params)
+    path = CACHE_DIR / page / f"{cache_id}.csv"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        df.to_csv(path, index=False)
+    except Exception:
+        pass
+    return cache_id
+
+
+def load_by_id(page: str, cache_id: str) -> Optional[pd.DataFrame]:
+    """Load cached DataFrame by cache id."""
+    path = CACHE_DIR / page / f"{cache_id}.csv"
+    if path.exists():
+        try:
+            return pd.read_csv(path)
+        except Exception:
+            return None
+    return None

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1,10 +1,10 @@
 import streamlit as st
 from app_pages.overview import render_overview
 from app_pages.ohlcv import render_ohlcv_page
-from app_pages.strong_assets import render_strong_assets_page
-from app_pages.bottom_lift import render_bottom_lift_page
+# from app_pages.strong_assets import render_strong_assets_page
+# from app_pages.bottom_lift import render_bottom_lift_page
 from app_pages.label_assets import render_label_assets_page
-from app_pages.price_change_by_label import render_price_change_by_label
+# from app_pages.price_change_by_label import render_price_change_by_label
 from app_pages.combined_analysis import render_combined_page
 from app_pages.watchlist import render_watchlist_page
 
@@ -20,9 +20,9 @@ PAGES = {
     "Overview": render_overview,
     "OHLCV": render_ohlcv_page,
     "综合分析": render_combined_page,
-    "强势标的筛选": render_strong_assets_page,
-    "底部抬升筛选": render_bottom_lift_page,
-    "标签化涨跌幅": render_price_change_by_label,
+    # "强势标的筛选": render_strong_assets_page,
+    # "底部抬升筛选": render_bottom_lift_page,
+    # "标签化涨跌幅": render_price_change_by_label,
     "自选跟踪": render_watchlist_page,
     "自选标的": render_watchlist_page,
 }


### PR DESCRIPTION
## Summary
- add disk-based result caching utilities
- integrate caching & history logging into strong, bottom lift and label pages
- add history and caching support to combined analysis
- hide extra pages from the menu

## Testing
- `python -m py_compile $(git ls-files '*.py')`