### PR TITLE
Fix datetime parsing from cached CSV

### DIFF
--- a/app_pages/combined_analysis.py
+++ b/app_pages/combined_analysis.py
@@ -10,7 +10,7 @@ from app_pages.price_change_by_label import (
     get_mappings,
     compute_period_metrics as label_compute,
 )
-from utils import update_shared_range, safe_rerun, short_time_range
+from utils import update_shared_range, safe_rerun, short_time_range, format_time_col
 from query_history import add_entry, get_history
 from result_cache import load_cached, save_cached
 
@@ -165,16 +165,8 @@ def render_combined_page():
             },
             {"sa_id": sa_cache_id},
         )
-        df["max_close_dt"] = (
-            pd.to_datetime(df["max_close_dt"], unit="ms", utc=True)
-            .dt.tz_convert("Asia/Shanghai")
-            .dt.strftime("%m-%d %H:%M")
-        )
-        df["min_close_dt"] = (
-            pd.to_datetime(df["min_close_dt"], unit="ms", utc=True)
-            .dt.tz_convert("Asia/Shanghai")
-            .dt.strftime("%m-%d %H:%M")
-        )
+        df["max_close_dt"] = format_time_col(df["max_close_dt"])
+        df["min_close_dt"] = format_time_col(df["min_close_dt"])
         df["period_return (%)"] = (df["period_return"] * 100).round(2)
         df["drawdown (%)"] = (df["drawdown"] * 100).round(2)
         df["标签"] = df["symbol"].map(

--- a/app_pages/strong_assets.py
+++ b/app_pages/strong_assets.py
@@ -4,7 +4,7 @@ from sqlalchemy import text
 from db import engine_ohlcv
 from strategies.strong_assets import compute_period_metrics
 from query_history import add_entry, get_history
-from utils import safe_rerun, short_time_range, update_shared_range
+from utils import safe_rerun, short_time_range, update_shared_range, format_time_col
 from result_cache import load_cached, save_cached
 import pandas as pd
 
@@ -154,16 +154,8 @@ def render_strong_assets_page():
         update_shared_range(start_date, start_time, end_date, end_time)
 
         # 转换最高/最低价时间戳为 UTC+8 并格式化为 MM-DD HH:MM
-        df["max_close_dt"] = (
-            pd.to_datetime(df["max_close_dt"], unit="ms", utc=True)
-            .dt.tz_convert("Asia/Shanghai")
-            .dt.strftime("%m-%d %H:%M")
-        )
-        df["min_close_dt"] = (
-            pd.to_datetime(df["min_close_dt"], unit="ms", utc=True)
-            .dt.tz_convert("Asia/Shanghai")
-            .dt.strftime("%m-%d %H:%M")
-        )
+        df["max_close_dt"] = format_time_col(df["max_close_dt"])
+        df["min_close_dt"] = format_time_col(df["min_close_dt"])
 
         # 计算百分比并四舍五入
         df["period_return (%)"] = (df["period_return"] * 100).round(2)

--- a/utils.py
+++ b/utils.py
@@ -1,6 +1,7 @@
 import re
 from datetime import datetime, timezone
 import pytz
+import pandas as pd
 from config import TZ_NAME
 import streamlit as st
 
@@ -61,3 +62,14 @@ def update_shared_range(start_date, start_time, end_date, end_time) -> None:
     st.session_state["range_start_time"] = start_time
     st.session_state["range_end_date"] = end_date
     st.session_state["range_end_time"] = end_time
+
+
+def format_time_col(col: pd.Series) -> pd.Series:
+    """Return formatted time strings for a column of ms timestamps or ISO datetimes."""
+    if pd.api.types.is_datetime64_any_dtype(col):
+        dt = col.dt.tz_convert("Asia/Shanghai")
+    else:
+        dt = pd.to_datetime(col, errors="coerce", unit="ms", utc=True)
+        dt_alt = pd.to_datetime(col, errors="coerce", utc=True)
+        dt = dt.fillna(dt_alt).dt.tz_convert("Asia/Shanghai")
+    return dt.dt.strftime("%m-%d %H:%M")


### PR DESCRIPTION
## Summary
- add `format_time_col` helper to handle cached ISO datetimes
- use helper for time columns in Strong Assets and Combined Analysis pages

## Testing
- `python -m py_compile $(git ls-files '*.py')`