### PR TITLE
Use secret_get for DB config

### DIFF
--- a/app_pages/hyperliquid_whale.py
+++ b/app_pages/hyperliquid_whale.py
@@ -8,6 +8,7 @@ import streamlit as st
 from datetime import datetime, timedelta
 from streamlit_autorefresh import st_autorefresh
 from dotenv import load_dotenv
+from config import secret_get
 
 load_dotenv()
 
@@ -16,11 +17,11 @@ def get_conn():
     创建并缓存数据库连接，使用 st.cache_resource
     """
     DB_CONFIG = {
-        'host': os.getenv('DB_HOST', '127.0.0.1'),
-        'port': os.getenv('DB_PORT', '5432'),
-        'dbname': os.getenv('INSTR_DB', 'postgres'),
-        'user': os.getenv('DB_USER', 'postgres'),
-        'password': os.getenv('DB_PASSWORD', ''),
+        'host': secret_get('DB_HOST', '127.0.0.1'),
+        'port': secret_get('DB_PORT', '5432'),
+        'dbname': secret_get('INSTR_DB', 'postgres'),
+        'user': secret_get('DB_USER', 'postgres'),
+        'password': secret_get('DB_PASSWORD', ''),
     }
 
     @st.cache_resource
@@ -183,7 +184,7 @@ def render_hyperliquid_whale_page():
     st_autorefresh(interval=5_000, key="hyperliquid_refresh")
 
     # 拉取并存储数据
-    api_key = os.getenv('CG_API_KEY')
+    api_key = secret_get('CG_API_KEY')
     if not api_key:
         st.error('未配置 CG_API_KEY')
         return

--- a/app_pages/label_assets.py
+++ b/app_pages/label_assets.py
@@ -5,6 +5,7 @@ import streamlit as st
 import pandas as pd
 import psycopg2
 from dotenv import load_dotenv
+from config import secret_get
 
 def render_label_assets_page():
     """
@@ -14,11 +15,11 @@ def render_label_assets_page():
     """
     load_dotenv()
     DB_CFG = {
-        'host':     os.getenv('DB_HOST', '127.0.0.1'),
-        'port':     os.getenv('DB_PORT', '5432'),
-        'dbname':   os.getenv('INSTR_DB', 'postgres'),
-        'user':     os.getenv('DB_USER', 'postgres'),
-        'password': os.getenv('DB_PASSWORD', ''),
+        'host':     secret_get('DB_HOST', '127.0.0.1'),
+        'port':     secret_get('DB_PORT', '5432'),
+        'dbname':   secret_get('INSTR_DB', 'postgres'),
+        'user':     secret_get('DB_USER', 'postgres'),
+        'password': secret_get('DB_PASSWORD', ''),
     }
     conn = psycopg2.connect(**DB_CFG)
     cur = conn.cursor()

--- a/app_pages/long_short_analysis.py
+++ b/app_pages/long_short_analysis.py
@@ -5,6 +5,7 @@ import psycopg2
 import altair as alt
 from datetime import timedelta
 from dotenv import load_dotenv
+from config import secret_get
 
 
 def render_long_short_analysis_page():
@@ -14,15 +15,15 @@ def render_long_short_analysis_page():
     load_dotenv()
     # 主数据：coinmarket_aggregated 数据库
     DB_CFG = {
-        'host': os.getenv('DB_HOST', '127.0.0.1'),
-        'port': os.getenv('DB_PORT', '5432'),
-        'dbname': os.getenv('DB_NAME', 'coinmarket_aggregated'),
-        'user': os.getenv('DB_USER', 'postgres'),
-        'password': os.getenv('DB_PASSWORD', ''),
+        'host': secret_get('DB_HOST', '127.0.0.1'),
+        'port': secret_get('DB_PORT', '5432'),
+        'dbname': secret_get('DB_NAME', 'coinmarket_aggregated'),
+        'user': secret_get('DB_USER', 'postgres'),
+        'password': secret_get('DB_PASSWORD', ''),
     }
     # instruments 表所在数据库（默认postgres）
     DB_CFG_INST = DB_CFG.copy()
-    DB_CFG_INST['dbname'] = os.getenv('INSTR_DB', 'postgres')
+    DB_CFG_INST['dbname'] = secret_get('INSTR_DB', 'postgres')
 
     @st.cache_data(ttl=60)
     def load_data():

--- a/app_pages/price_change_by_label.py
+++ b/app_pages/price_change_by_label.py
@@ -10,6 +10,7 @@ from sqlalchemy import text
 from db import engine_ohlcv
 import psycopg2
 from dotenv import load_dotenv
+from config import secret_get
 from utils import safe_rerun, short_time_range
 from query_history import add_entry, get_history
 from result_cache import load_cached, save_cached
@@ -17,11 +18,11 @@ from result_cache import load_cached, save_cached
 # —— 1. 读取环境 & 配置 ——
 load_dotenv()
 INSTR_DB = {
-    'host':   os.getenv('DB_HOST','127.0.0.1'),
-    'port':   os.getenv('DB_PORT','5432'),
-    'dbname': os.getenv('DB_NAME','postgres'),
-    'user':   os.getenv('DB_USER','postgres'),
-    'password': os.getenv('DB_PASSWORD',''),
+    'host':   secret_get('DB_HOST','127.0.0.1'),
+    'port':   secret_get('DB_PORT','5432'),
+    'dbname': secret_get('DB_NAME','postgres'),
+    'user':   secret_get('DB_USER','postgres'),
+    'password': secret_get('DB_PASSWORD',''),
 }
 
 def get_mappings():

--- a/app_pages/price_change_ranking.py
+++ b/app_pages/price_change_ranking.py
@@ -2,14 +2,15 @@ import os
 import streamlit as st
 import pandas as pd
 from sqlalchemy import create_engine
+from config import secret_get
 
 @st.cache_resource
 def get_engine():
-    host     = os.getenv('DB_HOST', '127.0.0.1')
-    port     = os.getenv('DB_PORT', '5432')
-    dbname   = os.getenv('INSTR_DB', 'postgres')
-    user     = os.getenv('DB_USER', 'postgres')
-    password = os.getenv('DB_PASSWORD', '')
+    host     = secret_get('DB_HOST', '127.0.0.1')
+    port     = secret_get('DB_PORT', '5432')
+    dbname   = secret_get('INSTR_DB', 'postgres')
+    user     = secret_get('DB_USER', 'postgres')
+    password = secret_get('DB_PASSWORD', '')
     url = f"postgresql://{user}:{password}@{host}:{port}/{dbname}"
     return create_engine(url)
 

--- a/get_ohlcv.py
+++ b/get_ohlcv.py
@@ -6,23 +6,24 @@ import requests
 import psycopg2
 from datetime import datetime, timezone, timedelta
 from dotenv import load_dotenv
+from config import secret_get
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from decimal import Decimal
 
 # 加载环境变量并校验
 load_dotenv()
-API_KEY = os.getenv("CG_API_KEY")
+API_KEY = secret_get("CG_API_KEY")
 if not API_KEY:
     print("请在 .env 中配置 CG_API_KEY", flush=True)
     sys.exit(1)
 
 # 数据库配置
 DB_CFG = {
-    "host": os.getenv("DB_HOST", "127.0.0.1"),
-    "port": os.getenv("DB_PORT", "5432"),
-    "dbname": os.getenv("DB_NAME", "postgres"),
-    "user": os.getenv("DB_USER", "postgres"),
-    "password": os.getenv("DB_PASSWORD", ""),
+    "host": secret_get("DB_HOST", "127.0.0.1"),
+    "port": secret_get("DB_PORT", "5432"),
+    "dbname": secret_get("DB_NAME", "postgres"),
+    "user": secret_get("DB_USER", "postgres"),
+    "password": secret_get("DB_PASSWORD", ""),
 }
 
 # 确保 ohlcv 表存在


### PR DESCRIPTION
## Summary
- keep DB settings consistent across app pages
- use `secret_get()` everywhere for database credentials

## Testing
- `python -m py_compile $(git ls-files '*.py')`