### PR TITLE
Fix fingerprint persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,11 @@ instead of calling the experimental API directly.
 
 When a user logs in successfully a fingerprint token is stored in
 `data/fingerprints.json`.  The token is also written to the URL as a
-query parameter.  If the browser reloads the app with this token it will
-log in automatically.  Each account is limited to a single fingerprint;
-attempting to log in from another browser yields `ERROR 01`.
+query parameter and saved to `localStorage`.  If the browser reloads the
+app (even after closing the tab) the stored token is restored to the URL
+so the user logs in automatically.  Each account is limited to a single
+fingerprint; attempting to log in from another browser yields
+`ERROR 01`.
+
+For best security, deploy the app behind HTTPS so the browser does not
+flag the page as insecure.

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -95,18 +95,20 @@ def require_login() -> bool:
                 fp_param = hashlib.md5(raw_id.encode()).hexdigest()
                 fingerprints[u] = fp_param
                 save_fingerprints(fingerprints)
-                st.query_params["fp"] = fp_param
             st.session_state["logged_in"] = True
             st.session_state["username"] = u
             st.components.v1.html(
                 f"""
                 <script>
+                const params = new URLSearchParams(window.location.search);
+                params.set('fp', '{fp_param}');
                 window.localStorage.setItem('deviceId', '{fp_param}');
+                window.location.search = params.toString();
                 </script>
                 """,
                 height=0,
             )
-            safe_rerun()
+            st.stop()
         else:
             st.error("用户名或密码错误")
     return False


### PR DESCRIPTION
## Summary
- persist fingerprint token across reloads by updating JS logic
- document fingerprint behavior and HTTPS recommendation

## Testing
- `pytest -q`