### PR TITLE
Restore bottom lift page, adjust analysis logic

### DIFF
--- a/app_pages/combined_analysis.py
+++ b/app_pages/combined_analysis.py
@@ -5,7 +5,6 @@ from datetime import datetime, date, time, timedelta, timezone as dt_timezone
 from sqlalchemy import text
 from db import engine_ohlcv
 from strategies.strong_assets import compute_period_metrics
-from strategies.bottom_lift import analyze_bottom_lift
 from app_pages.price_change_by_label import (
     get_mappings,
     compute_period_metrics as label_compute,
@@ -27,8 +26,6 @@ def render_combined_page():
         st.session_state["combo_start_time"] = time.fromisoformat(params["start_time"])
         st.session_state["combo_end_date"] = date.fromisoformat(params["end_date"])
         st.session_state["combo_end_time"] = time.fromisoformat(params["end_time"])
-        st.session_state["combo_bars"] = params.get("bars", 4)
-        st.session_state["combo_factor"] = params.get("factor", 100.0)
         update_shared_range(
             st.session_state["combo_start_date"],
             st.session_state["combo_start_time"],
@@ -108,9 +105,6 @@ def render_combined_page():
     # normally collected later from widgets, but may not be available when
     # running the strong assets section first. Fetch them from session
     # state with defaults so they are always defined.
-    bars = st.session_state.get("combo_bars", 4)
-    factor = float(st.session_state.get("combo_factor", 100.0))
-
     run_all = st.button("一键分析", key="combo_all_btn")
 
     history_params = {
@@ -118,8 +112,6 @@ def render_combined_page():
         "start_time": start_time.isoformat(),
         "end_date": end_date.isoformat(),
         "end_time": end_time.isoformat(),
-        "bars": bars,
-        "factor": factor,
     }
     history_extra = {}
 
@@ -210,60 +202,6 @@ def render_combined_page():
         )
         st.dataframe(df, use_container_width=True)
 
-    st.subheader("底部抬升筛选")
-    bars = st.number_input(
-        "± N 根 K 线 (bars)", min_value=1, value=st.session_state.get("combo_bars", 4), step=1, key="combo_bars"
-    )
-    factor = st.number_input(
-        "放大因子 (factor)", min_value=1.0, value=float(st.session_state.get("combo_factor", 100.0)), step=1.0, key="combo_factor"
-    )
-    run_bl = st.button("运行底部抬升分析", key="combo_bl_btn")
-    if run_bl or run_all:
-        bl_params = {
-            "t1": start_dt.isoformat(),
-            "t2": end_dt.isoformat(),
-            "bars": bars,
-            "factor": factor,
-        }
-        bl_cache_id, df = load_cached("bottom_lift", bl_params)
-        expected_cols = {"L1_time", "L1_low", "L2_time", "L2_low", "slope"}
-        if df is None or not expected_cols.issubset(df.columns):
-            df = analyze_bottom_lift(start_dt, end_dt, bars=bars, factor=factor)
-            if df.empty:
-                st.warning("无符合条件的数据")
-                return
-            save_cached("bottom_lift", bl_params, df)
-
-        history_extra["bl_id"] = bl_cache_id
-        if not run_all:
-            add_entry(
-                "combined_analysis",
-                user,
-                history_params,
-                {"bl_id": bl_cache_id},
-            )
-
-        with engine_ohlcv.connect() as conn:
-            result = conn.execute(text("SELECT instrument_id, labels FROM instruments"))
-            labels_map = {instr_id: labels for instr_id, labels in result}
-        df["标签"] = df.index.map(
-            lambda s: "，".join(labels_map.get(s, [])) if labels_map.get(s) else ""
-        )
-        df["L1_time"] = (
-            pd.to_datetime(df["L1_time"], utc=True)
-            .dt.tz_convert("Asia/Shanghai")
-            .dt.strftime("%m-%d %H:%M")
-        )
-        df["L2_time"] = (
-            pd.to_datetime(df["L2_time"], utc=True)
-            .dt.tz_convert("Asia/Shanghai")
-            .dt.strftime("%m-%d %H:%M")
-        )
-        df = df.reset_index()
-        df = df[["标签", "symbol", "L1_time", "L1_low", "L2_time", "L2_low", "slope"]]
-        df = df.rename(columns={"symbol": "代币名字"})
-        df = df.sort_values("slope", ascending=False).reset_index(drop=True)
-        st.dataframe(df, use_container_width=True)
 
     st.subheader("标签化涨跌幅")
     run_label = st.button("计算标签涨跌幅", key="combo_label_btn")

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -2,7 +2,7 @@ import streamlit as st
 from app_pages.overview import render_overview
 from app_pages.ohlcv import render_ohlcv_page
 # from app_pages.strong_assets import render_strong_assets_page
-# from app_pages.bottom_lift import render_bottom_lift_page
+from app_pages.bottom_lift import render_bottom_lift_page
 from app_pages.label_assets import render_label_assets_page
 # from app_pages.price_change_by_label import render_price_change_by_label
 from app_pages.combined_analysis import render_combined_page
@@ -18,9 +18,8 @@ PAGES = {
     "历史排名": render_history_rank,
     "综合分析": render_combined_page,
     # "强势标的筛选": render_strong_assets_page,
-    # "底部抬升筛选": render_bottom_lift_page,
+    "底部抬升筛选": render_bottom_lift_page,
     # "标签化涨跌幅": render_price_change_by_label,
-    "自选跟踪": render_watchlist_page,
     "自选标的": render_watchlist_page,
 }
 # 动态添加


### PR DESCRIPTION
## Summary
- remove bottom lift section from **综合分析** page
- restore standalone bottom lift page in navigation
- deduplicate watchlist menu entry
- compute label returns using raw data interval

## Testing
- `python -m py_compile app_pages/combined_analysis.py app_pages/price_change_by_label.py streamlit_app.py`