### PR TITLE
Revert to env-based Grok API key

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,9 +86,3 @@ previous ID, immediately invalidating the old session.
 
 For best security, deploy the app behind HTTPS so the browser does not
 flag the page as insecure.
-
-## Grok API key
-
-The "AI-强势标的" page requires access to Grok's search API. You can set the
-`GROK_API_KEY` environment variable, or simply enter your key in the page when
-prompted. The provided key will be used for the search requests.

--- a/app_pages/ai_strong_assets.py
+++ b/app_pages/ai_strong_assets.py
@@ -13,8 +13,6 @@ from grok_search import live_search_summary, x_search_summary, bubble_market_sum
 def render_ai_strong_assets_page():
     st.header("AI-强势标的")
 
-    api_key = st.text_input("Grok API Key", type="password", key="ai_sa_api_key")
-
     # —— 历史记录侧边栏 ——
     user = st.session_state.get("username", "default")
     history = get_history("ai_strong_assets", user)
@@ -219,9 +217,7 @@ def render_ai_strong_assets_page():
                     s_date = st.session_state.get("ai_sa_start_date")
                     e_date = st.session_state.get("ai_sa_end_date")
                     try:
-                        url, summary = x_search_summary(
-                            symbol, s_date, e_date, api_key=api_key
-                        )
+                        url, summary = x_search_summary(symbol, s_date, e_date)
                     except Exception as exc:
                         st.error(f"搜索失败: {exc}")
                     else:
@@ -231,7 +227,7 @@ def render_ai_strong_assets_page():
             if st.button("市场整体描述", key="ai_sa_market"):
                 with st.spinner("搜索中..."):
                     try:
-                        summary = bubble_market_summary(api_key=api_key)
+                        summary = bubble_market_summary()
                     except Exception as exc:
                         st.error(f"搜索失败: {exc}")
                     else:

--- a/grok_search.py
+++ b/grok_search.py
@@ -7,7 +7,7 @@ from urllib.parse import quote_plus
 GROK_API_KEY = os.getenv("GROK_API_KEY")
 API_URL = "https://api.grok.x.ai/v1/search"  # Placeholder
 
-def live_search(query: str, limit: int = 5, api_key: str | None = None) -> dict:
+def live_search(query: str, limit: int = 5) -> dict:
     """Perform a live search using Grok's API.
 
     Parameters
@@ -21,20 +21,18 @@ def live_search(query: str, limit: int = 5, api_key: str | None = None) -> dict:
     dict
         Parsed JSON response from the API.
     """
-    if api_key is None:
-        api_key = GROK_API_KEY
-    if not api_key:
+    if not GROK_API_KEY:
         raise RuntimeError("GROK_API_KEY not configured")
-    headers = {"Authorization": f"Bearer {api_key}"}
+    headers = {"Authorization": f"Bearer {GROK_API_KEY}"}
     payload = {"query": query, "limit": limit}
     resp = requests.post(API_URL, json=payload, headers=headers, timeout=10)
     resp.raise_for_status()
     return resp.json()
 
 
-def live_search_summary(query: str, limit: int = 10, api_key: str | None = None) -> str:
+def live_search_summary(query: str, limit: int = 10) -> str:
     """Search Grok and return a Chinese summary of the results."""
-    data = live_search(query, limit=limit, api_key=api_key)
+    data = live_search(query, limit=limit)
     items = []
     for item in data.get("results", []):
         title = item.get("title", "")
@@ -66,27 +64,21 @@ def build_x_search_url(instrument_id: str, start: date, end: date) -> str:
     return "https://x.com/search?f=live&q=" + quote_plus(q) + "&src=typed_query"
 
 
-def x_search_summary(
-    instrument_id: str,
-    start: date,
-    end: date,
-    limit: int = 10,
-    api_key: str | None = None,
-) -> tuple[str, str]:
+def x_search_summary(instrument_id: str, start: date, end: date, limit: int = 10) -> tuple[str, str]:
     """Summarize X search results for the given instrument and period."""
     url = build_x_search_url(instrument_id, start, end)
-    summary = live_search_summary(url, limit=limit, api_key=api_key)
+    summary = live_search_summary(url, limit=limit)
     return url, summary
 
 
-def bubble_market_summary(limit: int = 10, api_key: str | None = None) -> str:
+def bubble_market_summary(limit: int = 10) -> str:
     """Fetch cryptobubbles data and return a summary via Grok."""
     url = "https://cryptobubbles.net/backend/data/bubbles1000.usd.json"
     resp = requests.get(url, timeout=10)
     resp.raise_for_status()
     data = resp.text
     # Pass raw JSON to Grok for summarization
-    return live_search_summary(data, limit=limit, api_key=api_key)
+    return live_search_summary(data, limit=limit)
 
 if __name__ == "__main__":
     import sys, json


### PR DESCRIPTION
## Summary
- drop Grok API key input field and revert README
- remove `api_key` parameters from Grok helper functions

## Testing
- `pytest -q`