### PR TITLE
Override env vars with .env

### DIFF
--- a/config.py
+++ b/config.py
@@ -6,7 +6,8 @@ try:
 except ModuleNotFoundError:
     st = None
 
-load_dotenv()
+# Load variables from .env, overriding existing environment
+load_dotenv(override=True)
 
 
 def secret_get(key: str, default: str = ""):


### PR DESCRIPTION
## Summary
- load .env with override so its variables replace existing env values

## Testing
- `pytest -q`