### PR TITLE
Enable SOCKS proxy support

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,16 @@ bob   = "pass2"
 
 Environment variables still take precedence if both are provided.
 
+## Requirements
+
+Install dependencies with `pip`:
+```bash
+pip install -r requirements.txt
+```
+
+The `pysocks` package is included to support SOCKS proxies.
+
+
 ## Database settings
 
 The app connects to PostgreSQL using the host, port, username and

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ streamlit-autorefresh>=0.1
 requests>=2.0
 numpy>=1.21
 googletrans==4.0.0-rc1
+pysocks>=1.7


### PR DESCRIPTION
## Summary
- add `pysocks>=1.7` to requirements
- document Python requirements in README

## Testing
- `pytest -q`