### PR TITLE
Fix 4h aggregation logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,4 +122,5 @@ data ends on the 30 minute mark) are discarded. Aggregation starts from
 
 Aggregated 4h candles are cached under `data/cache/4h` as CSV files to
 avoid recomputing from raw 15 minute data. Each query updates the cache
-with any new records.
+with any new records and the bot keeps aggregated results in memory to
+speed up repeated checks.

--- a/app_pages/watchlist.py
+++ b/app_pages/watchlist.py
@@ -32,16 +32,27 @@ def save_watchlist(lst: list[str]) -> None:
 
 
 def aggregate_4h(df: pd.DataFrame) -> pd.DataFrame:
+    """Aggregate 15m candles into 4h bars aligned to 00:00/04:00/08:00..."""
     df = df.set_index("dt").sort_index()
-    counts = df["open"].resample("4H").count()
+    df.index = df.index.floor("15min")
+    rs = df.resample(
+        "4H",
+        label="left",
+        closed="left",
+        origin="epoch",
+        offset="0H",
+    )
+
+    counts = rs["open"].count()
     complete = counts[counts == 16].index
     if complete.empty:
         return pd.DataFrame()
-    o = df["open"].resample("4H").first().loc[complete]
-    h = df["high"].resample("4H").max().loc[complete]
-    l = df["low"].resample("4H").min().loc[complete]
-    c = df["close"].resample("4H").last().loc[complete]
-    v = df["volume_usd"].resample("4H").sum().loc[complete]
+
+    o = rs["open"].first().loc[complete]
+    h = rs["high"].max().loc[complete]
+    l = rs["low"].min().loc[complete]
+    c = rs["close"].last().loc[complete]
+    v = rs["volume_usd"].sum().loc[complete]
     res = pd.DataFrame({"open": o, "high": h, "low": l, "close": c, "volume": v})
     res = res.reset_index().rename(columns={"dt": "start"})
     return res


### PR DESCRIPTION
## Summary
- align 4h aggregation windows to 00:00/04:00/08:00, etc.
- keep aggregated 4h data in memory for faster updates
- mention caching behaviour in README
- update Streamlit watchlist page to use the new aggregation logic

## Testing
- `python3 -m py_compile monitor_bot.py app_pages/watchlist.py`