### PR TITLE
Fix 4h streak script to traverse full history

### DIFF
--- a/test4h.py
+++ b/test4h.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Compute consecutive 4h up candles for all symbols."""
+import psycopg2
+from config import secret_get
+
+DB_CFG = {
+    "host": secret_get("DB_HOST", "127.0.0.1"),
+    "port": secret_get("DB_PORT", "5432"),
+    "dbname": secret_get("DB_NAME", "ohlcv_4h"),
+    "user": secret_get("DB_USER", "postgres"),
+    "password": secret_get("DB_PASSWORD", ""),
+}
+
+
+def get_symbols():
+    conn = psycopg2.connect(**DB_CFG)
+    cur = conn.cursor()
+    cur.execute("SELECT DISTINCT symbol FROM ohlcv_4h")
+    symbols = [row[0] for row in cur.fetchall()]
+    cur.close()
+    conn.close()
+    return symbols
+
+
+def fetch_closes(symbol: str):
+    conn = psycopg2.connect(**DB_CFG)
+    cur = conn.cursor()
+    cur.execute(
+        "SELECT close FROM ohlcv_4h WHERE symbol=%s ORDER BY time DESC",
+        (symbol,),
+    )
+    closes = [float(r[0]) for r in cur.fetchall()]
+    cur.close()
+    conn.close()
+    return closes
+
+
+def consecutive_up_count(closes):
+    count = 0
+    for i in range(len(closes) - 1):
+        if closes[i + 1] < closes[i]:
+            count += 1
+        else:
+            break
+    if count:
+        start = closes[count]
+        end = closes[0]
+        pct = (end - start) / start * 100 if start else 0.0
+    else:
+        pct = 0.0
+    return count, pct
+
+
+def main():
+    symbols = get_symbols()
+    results = []
+    for sym in symbols:
+        closes = fetch_closes(sym)
+        if not closes:
+            continue
+        count, pct = consecutive_up_count(closes)
+        results.append((sym, count, pct))
+    results.sort(key=lambda x: x[1], reverse=True)
+    top10 = results[:10]
+    print(f"{'symbol':<10} {'count':>5} {'累计涨幅':>10}")
+    for sym, c, pct in top10:
+        print(f"{sym:<10} {c:>5} {pct:>9.2f}%")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- tweak `test4h.py` to pull all closes so the streak is computed from the latest candle backward

## Testing
- `python -m py_compile test4h.py`


------
https://chatgpt.com/codex/tasks/task_e_683c340a99b0832cbf41aa911e35472b