### PR TITLE
Add 4h breakout logic and scheduler

### DIFF
--- a/alert_scheduler.py
+++ b/alert_scheduler.py
@@ -13,7 +13,7 @@ from monitor_bot import (
 def main() -> None:
     ensure_table()
     ensure_up_tables()
-    send_message("4h 连涨警报开始运行")
+    send_message("alert scheduler started")
     while True:
         start = time.time()
         check_prices()

--- a/app_pages/monitor.py
+++ b/app_pages/monitor.py
@@ -79,6 +79,21 @@ def render_monitor():
     ensure_table()
     st.header("Monitor")
 
+    if "p1_locked" not in st.session_state:
+        st.session_state["p1_locked"] = True
+    locked = st.session_state["p1_locked"]
+
+    lock_col1, lock_col2 = st.columns(2)
+    with lock_col1:
+        if locked:
+            if st.button("解锁 P1"):
+                st.session_state["p1_locked"] = False
+        else:
+            if st.button("锁定 P1"):
+                st.session_state["p1_locked"] = True
+    if locked:
+        st.info("P1 已锁定，解锁后才能重新计算")
+
     col1, col2 = st.columns(2)
     with col1:
         start_date = st.date_input("开始日期", date.today() - timedelta(days=7))
@@ -87,7 +102,7 @@ def render_monitor():
         end_date = st.date_input("结束日期", date.today())
         end_time = st.time_input("结束时间", time(23, 59))
 
-    if st.button("计算并保存 P1"):
+    if st.button("计算并保存 P1", disabled=locked):
         tz = dt_timezone(timedelta(hours=8))
         start_dt = datetime.combine(start_date, start_time).replace(tzinfo=tz)
         end_dt = datetime.combine(end_date, end_time).replace(tzinfo=tz)


### PR DESCRIPTION
## Summary
- add lock/unlock for P1 editing in monitor page
- move 4h streak logic from `test4h.py` into `monitor_bot`
- improve price breakout alert with volume check
- update alert scheduler message

## Testing
- `python -m py_compile monitor_bot.py alert_scheduler.py app_pages/monitor.py`

------
https://chatgpt.com/codex/tasks/task_e_683ea14341a8832c8650be2c0abfb4f6