### PR TITLE
Fix scheduler to run on 15 minute boundaries

### DIFF
--- a/alert_scheduler.py
+++ b/alert_scheduler.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """Run price breakout and 4h up alerts every 15 minutes."""
 import time
+from datetime import datetime, timedelta
 from monitor_bot import (
     ensure_table,
     ensure_up_tables,
@@ -14,14 +15,28 @@ def main() -> None:
     ensure_table()
     ensure_up_tables()
     send_message("alert scheduler started")
+    # first run aligned to the next quarter hour
+    def next_quarter(dt: datetime) -> datetime:
+        dt = dt.replace(second=0, microsecond=0)
+        minute = (dt.minute // 15 + 1) * 15
+        if minute >= 60:
+            dt = dt.replace(minute=0) + timedelta(hours=1)
+        else:
+            dt = dt.replace(minute=minute)
+        return dt
+
+    next_run = next_quarter(datetime.now())
     while True:
-        start = time.time()
-        check_prices()
-        check_up_alert()
-        # Sleep until next 15 minute slot
-        elapsed = time.time() - start
-        sleep_time = max(900 - elapsed, 1)
-        time.sleep(sleep_time)
+        now = datetime.now()
+        if now >= next_run:
+            check_prices()
+            check_up_alert()
+            next_run = next_quarter(now)
+        sleep = min(120, (next_run - now).total_seconds())
+        if sleep > 0:
+            time.sleep(sleep)
+        else:
+            time.sleep(120)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- align `alert_scheduler.py` with 00/15/30/45 minute slots
- limit sleep to 120 seconds between checks

## Testing
- `python -m py_compile alert_scheduler.py`

------
https://chatgpt.com/codex/tasks/task_e_683eaff7ae5c832c99440739e8eb8ee5