### PR TITLE
Add test script for Grok API

### DIFF
--- a/testgrok.py
+++ b/testgrok.py
@@ -1,0 +1,23 @@
+import os
+import requests
+from config import load_proxy_env, get_proxy_dict
+
+load_proxy_env()
+PROXIES = get_proxy_dict()
+
+API_URL = "https://api.x.ai/v1/chat/completions"
+
+payload = {
+    "messages": [
+        {"role": "user", "content": "输出今天上海的天气情况"}
+    ],
+    "model": "grok-3-latest",
+}
+
+headers = {
+    "Content-Type": "application/json",
+    "Authorization": f"Bearer {os.getenv('XAI_API_KEY')}"
+}
+
+response = requests.post(API_URL, headers=headers, json=payload, proxies=PROXIES or None)
+print(response.json())


### PR DESCRIPTION
## Summary
- add `testgrok.py` showing how to query the Grok API using proxy env vars

## Testing
- `python -m py_compile testgrok.py`

------
https://chatgpt.com/codex/tasks/task_e_683feafce338832cb2473030bbaf93fe