### PR TITLE
Modify label selection on combined analysis

### DIFF
--- a/app_pages/combined_analysis.py
+++ b/app_pages/combined_analysis.py
@@ -12,7 +12,6 @@ from app_pages.price_change_by_label import (
 from utils import update_shared_range, safe_rerun, short_time_range, format_time_col
 from query_history import add_entry, get_history
 from result_cache import load_cached, save_cached
-from label_watchlist import load_label_watchlist, save_label_watchlist
 
 
 def render_combined_page():
@@ -284,34 +283,13 @@ def render_combined_page():
         st.dataframe(stats, use_container_width=True)
 
         # ---- Selected label board ----
-        watchlist = load_label_watchlist()
-        with st.expander("管理关注标签", expanded=False):
-            options = stats["标签"].tolist()
-            add_lbl = st.selectbox(
-                "添加关注标签", [l for l in options if l not in watchlist], key="combo_lbl_add"
-            )
-            if st.button("添加", key="combo_lbl_add_btn"):
-                if add_lbl and add_lbl not in watchlist:
-                    watchlist.append(add_lbl)
-                    save_label_watchlist(watchlist)
-                    st.success(f"已添加 {add_lbl}")
-                    safe_rerun()
-            if watchlist:
-                for lbl in watchlist:
-                    if st.button(f"删除 {lbl}", key=f"combo_del_{lbl}"):
-                        watchlist.remove(lbl)
-                        save_label_watchlist(watchlist)
-                        safe_rerun()
-            else:
-                st.write("暂无关注标签")
+        options = stats["标签"].tolist()
+        selected = st.multiselect("选择标签", options, key="combo_lbl_select")
 
-        if watchlist:
-            st.subheader("关注标签表现")
-            sel = stats[stats["标签"].isin(watchlist)]
-            if not sel.empty:
-                st.dataframe(sel, use_container_width=True)
-            else:
-                st.info("关注标签未出现在当前结果中")
+        if selected:
+            st.subheader("自选标签表现")
+            sel = stats[stats["标签"].isin(selected)]
+            st.dataframe(sel, use_container_width=True)
 
         for bucket in pivot.columns[::-1]:
             df_b = df[df["bucket"] == bucket]


### PR DESCRIPTION
## Summary
- simplify combined analysis page by removing label watchlist
- allow choosing labels directly and show stats for them

## Testing
- `pytest -q`
- `flake8` *(fails: command not found)*
- `python -m py_compile app_pages/combined_analysis.py`


------
https://chatgpt.com/codex/tasks/task_e_6841ce9320c8832caf8e5d1a95f4b1e2