### PR TITLE
Fix database selection for Tron bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ DB_HOST     # database address, e.g. 127.0.0.1 for local testing
 DB_PORT     # usually 5432
 DB_USER     # database user
 DB_PASSWORD # database password
+TRON_DB_NAME # database used by tron_bot.py (defaults to DB_NAME)
 ```
 
 For example, a local `.env` could look like:

--- a/tron_bot.py
+++ b/tron_bot.py
@@ -16,7 +16,7 @@ load_dotenv()
 DB_CFG = {
     "host": secret_get("DB_HOST", "127.0.0.1"),
     "port": secret_get("DB_PORT", "5432"),
-    "dbname": "tron_usd1",
+    "dbname": secret_get("TRON_DB_NAME", secret_get("DB_NAME", "tron_usd1")),
     "user": secret_get("DB_USER", "postgres"),
     "password": secret_get("DB_PASSWORD", ""),
 }


### PR DESCRIPTION
## Summary
- add a `TRON_DB_NAME` variable so `tron_bot.py` doesn't rely on a hard-coded database
- document the new variable in the README

## Testing
- `pytest -q`
- `python -m py_compile tron_bot.py`


------
https://chatgpt.com/codex/tasks/task_e_684a7d8a55f8832cb7a2800171355cd0