### PR TITLE
Add quick time range buttons

### DIFF
--- a/app_pages/ai_strong_assets.py
+++ b/app_pages/ai_strong_assets.py
@@ -4,7 +4,13 @@ from sqlalchemy import text
 from db import engine_ohlcv
 from strategies.strong_assets import compute_period_metrics
 from query_history import add_entry, get_history
-from utils import safe_rerun, short_time_range, update_shared_range, format_time_col
+from utils import (
+    safe_rerun,
+    short_time_range,
+    update_shared_range,
+    format_time_col,
+    quick_range_buttons,
+)
 from result_cache import load_cached, save_cached
 import pandas as pd
 from grok_search import live_search_summary, x_search_summary
@@ -108,6 +114,13 @@ def render_ai_strong_assets_page():
             ),
             key="ai_sa_end_time",
         )
+
+    quick_range_buttons(
+        "ai_sa_start_date",
+        "ai_sa_start_time",
+        "ai_sa_end_date",
+        "ai_sa_end_time",
+    )
 
     if st.button("计算区间指标", key="ai_sa_btn"):
         # 合并日期时间并转毫秒，内部计算使用 UTC+8 时区

--- a/app_pages/bottom_lift.py
+++ b/app_pages/bottom_lift.py
@@ -5,7 +5,12 @@ from db import engine_ohlcv
 from strategies.bottom_lift import analyze_bottom_lift
 import pandas as pd
 from query_history import add_entry, get_history
-from utils import safe_rerun, short_time_range, update_shared_range
+from utils import (
+    safe_rerun,
+    short_time_range,
+    update_shared_range,
+    quick_range_buttons,
+)
 from result_cache import load_cached, save_cached
 
 
@@ -97,6 +102,8 @@ def render_bottom_lift_page():
             ),
             key="t2_time",
         )
+
+    quick_range_buttons("t1_date", "t1_time", "t2_date", "t2_time")
 
     # 可调参数：bars (窗口大小) 和 factor (放大因子)
     bars = st.number_input("± N 根 K 线 (bars)", min_value=1, value=4, step=1)

--- a/app_pages/combined_analysis.py
+++ b/app_pages/combined_analysis.py
@@ -9,7 +9,13 @@ from app_pages.price_change_by_label import (
     get_mappings,
     compute_period_metrics as label_compute,
 )
-from utils import update_shared_range, safe_rerun, short_time_range, format_time_col
+from utils import (
+    update_shared_range,
+    safe_rerun,
+    short_time_range,
+    format_time_col,
+    quick_range_buttons,
+)
 from query_history import add_entry, get_history
 from result_cache import load_cached, save_cached
 from app_pages.watchlist import load_watchlist, save_watchlist
@@ -94,6 +100,13 @@ def render_combined_page():
             ),
             key="combo_end_time",
         )
+
+    quick_range_buttons(
+        "combo_start_date",
+        "combo_start_time",
+        "combo_end_date",
+        "combo_end_time",
+    )
 
     tz = dt_timezone(timedelta(hours=8))
     start_dt = datetime.combine(start_date, start_time).replace(tzinfo=tz)

--- a/app_pages/history.py
+++ b/app_pages/history.py
@@ -2,6 +2,7 @@ import streamlit as st
 from datetime import datetime, timedelta, time
 from db import engine_coin
 from queries import fetch_coinmarkets_history, fetch_instruments
+from utils import quick_range_buttons
 
 def render_history():
     st.header("历史数据查询")
@@ -12,6 +13,13 @@ def render_history():
     start_time = st.time_input("开始时间", time(0, 0), key="hist_start_time")
     end_date   = st.date_input("结束日期", datetime.now(), key="hist_end_date")
     end_time   = st.time_input("结束时间", time(23, 59), key="hist_end_time")
+
+    quick_range_buttons(
+        "hist_start_date",
+        "hist_start_time",
+        "hist_end_date",
+        "hist_end_time",
+    )
 
     if st.button("查询", key="hist_btn"):
         # combine date + time → datetime

--- a/app_pages/monitor.py
+++ b/app_pages/monitor.py
@@ -3,7 +3,7 @@ import pandas as pd
 from datetime import datetime, date, time, timedelta, timezone as dt_timezone
 from sqlalchemy import text
 
-from utils import safe_rerun
+from utils import safe_rerun, quick_range_buttons
 
 from db import engine_ohlcv
 from config import TZ_NAME
@@ -96,11 +96,22 @@ def render_monitor():
 
     col1, col2 = st.columns(2)
     with col1:
-        start_date = st.date_input("开始日期", date.today() - timedelta(days=7))
-        start_time = st.time_input("开始时间", time(0, 0))
+        start_date = st.date_input(
+            "开始日期",
+            date.today() - timedelta(days=7),
+            key="monitor_start_date",
+        )
+        start_time = st.time_input("开始时间", time(0, 0), key="monitor_start_time")
     with col2:
-        end_date = st.date_input("结束日期", date.today())
-        end_time = st.time_input("结束时间", time(23, 59))
+        end_date = st.date_input("结束日期", date.today(), key="monitor_end_date")
+        end_time = st.time_input("结束时间", time(23, 59), key="monitor_end_time")
+
+    quick_range_buttons(
+        "monitor_start_date",
+        "monitor_start_time",
+        "monitor_end_date",
+        "monitor_end_time",
+    )
 
     if st.button("计算并保存 P1", disabled=locked):
         tz = dt_timezone(timedelta(hours=8))

--- a/app_pages/ohlcv.py
+++ b/app_pages/ohlcv.py
@@ -3,6 +3,7 @@ from datetime import datetime, timedelta, time
 from db import engine_ohlcv
 from queries import fetch_ohlcv, fetch_instruments
 import pandas as pd
+from utils import quick_range_buttons
 
 def render_ohlcv_page():
     st.header("OHLCV 数据展示")
@@ -15,6 +16,13 @@ def render_ohlcv_page():
     start_time = st.time_input("开始时间", time(0, 0), key="ohlcv_start_time")
     end_date = st.date_input("结束日期", datetime.now(), key="ohlcv_end_date")
     end_time = st.time_input("结束时间", time(23, 59), key="ohlcv_end_time")
+
+    quick_range_buttons(
+        "ohlcv_start_date",
+        "ohlcv_start_time",
+        "ohlcv_end_date",
+        "ohlcv_end_time",
+    )
 
     if st.button("加载", key="ohlcv_btn"):
         # 用户输入的日期时间转换为毫秒级时间戳

--- a/app_pages/price_change_by_label.py
+++ b/app_pages/price_change_by_label.py
@@ -11,7 +11,7 @@ from db import engine_ohlcv
 import psycopg2
 from dotenv import load_dotenv
 from config import secret_get
-from utils import safe_rerun, short_time_range
+from utils import safe_rerun, short_time_range, quick_range_buttons
 from query_history import add_entry, get_history
 from result_cache import load_cached, save_cached
 
@@ -116,17 +116,27 @@ def render_price_change_by_label():
         sd = st.date_input(
             "开始日期",
             sd or (now.date() - timedelta(hours=4)),
+            key="pcl_start_date",
         )
         stime = st.time_input(
             "开始时间",
             stime or time(now.hour, now.minute),
+            key="pcl_start_time",
         )
     with c2:
-        ed = st.date_input("结束日期", ed or now.date())
+        ed = st.date_input("结束日期", ed or now.date(), key="pcl_end_date")
         etime = st.time_input(
             "结束时间",
             etime or time(now.hour, now.minute),
+            key="pcl_end_time",
         )
+
+    quick_range_buttons(
+        "pcl_start_date",
+        "pcl_start_time",
+        "pcl_end_date",
+        "pcl_end_time",
+    )
     start_dt = datetime(sd.year, sd.month, sd.day, stime.hour, stime.minute, tzinfo=timezone.utc)
     end_dt   = datetime(ed.year, ed.month, ed.day, etime.hour, etime.minute, tzinfo=timezone.utc)
     start_custom_ts = int(start_dt.timestamp()*1000)

--- a/app_pages/strong_assets.py
+++ b/app_pages/strong_assets.py
@@ -4,7 +4,13 @@ from sqlalchemy import text
 from db import engine_ohlcv
 from strategies.strong_assets import compute_period_metrics
 from query_history import add_entry, get_history
-from utils import safe_rerun, short_time_range, update_shared_range, format_time_col
+from utils import (
+    safe_rerun,
+    short_time_range,
+    update_shared_range,
+    format_time_col,
+    quick_range_buttons,
+)
 from result_cache import load_cached, save_cached
 import pandas as pd
 
@@ -103,6 +109,13 @@ def render_strong_assets_page():
             ),
             key="sa_end_time",
         )
+
+    quick_range_buttons(
+        "sa_start_date",
+        "sa_start_time",
+        "sa_end_date",
+        "sa_end_time",
+    )
 
     if st.button("计算区间指标", key="sa_btn"):
         # 合并日期时间并转毫秒，内部计算使用 UTC+8 时区

--- a/app_pages/watchlist.py
+++ b/app_pages/watchlist.py
@@ -5,7 +5,7 @@ from datetime import datetime, date, time, timedelta, timezone
 
 import pandas as pd
 import streamlit as st
-from utils import safe_rerun
+from utils import safe_rerun, quick_range_buttons
 from sqlalchemy import text
 
 from db import engine_ohlcv
@@ -136,11 +136,22 @@ def render_watchlist_page():
     # ---- 时间区间选择 ----
     col1, col2 = st.columns(2)
     with col1:
-        sd = st.date_input("开始日期", date.today() - timedelta(days=7))
-        stime = st.time_input("开始时间", time(0, 0))
+        sd = st.date_input(
+            "开始日期",
+            date.today() - timedelta(days=7),
+            key="watch_start_date",
+        )
+        stime = st.time_input("开始时间", time(0, 0), key="watch_start_time")
     with col2:
-        ed = st.date_input("结束日期", date.today())
-        etime = st.time_input("结束时间", time(23, 59))
+        ed = st.date_input("结束日期", date.today(), key="watch_end_date")
+        etime = st.time_input("结束时间", time(23, 59), key="watch_end_time")
+
+    quick_range_buttons(
+        "watch_start_date",
+        "watch_start_time",
+        "watch_end_date",
+        "watch_end_time",
+    )
 
     if st.button("计算", key="watch_calc"):
         tz = timezone(timedelta(hours=8))


### PR DESCRIPTION
## Summary
- add `quick_range_buttons` helper to utils
- add quick range buttons to pages with manual time ranges
- assign unique keys where missing

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6859266ad3e4832c87327a008293ad5c