### PR TITLE
Fix Coinglass history fetch range

### DIFF
--- a/get_ohlcv_1h.py
+++ b/get_ohlcv_1h.py
@@ -16,6 +16,9 @@ REQ_TIMESTAMPS = []
 MAX_REQS_PER_MIN = 79
 REQ_LOCK = threading.Lock()
 
+# API request limit
+LIMIT = 4500
+
 # 加载环境变量并校验
 load_dotenv()
 API_KEY = secret_get("CG_API_KEY")
@@ -109,7 +112,7 @@ def build_url(symbol: str, start_ts: int, end_ts: int) -> str:
         f"?exchange=Binance"
         f"&symbol={symbol}"
         f"&interval=1h"
-        f"&limit=4500"
+        f"&limit={LIMIT}"
         f"&start_time={start_ts}"
         f"&end_time={end_ts}"
     )
@@ -177,10 +180,10 @@ def process_symbol(symbol: str, end_ts: int, tz8, interval: int) -> tuple[int, i
         return 0, 0
 
     if latest is None:
-        start_ts = end_ts - interval * 4500
+        start_ts = end_ts - interval * LIMIT
     else:
         start_ts = latest + interval
-        min_start = end_ts - interval * 4500
+        min_start = end_ts - interval * LIMIT
         if start_ts < min_start:
             start_ts = min_start
 

--- a/get_ohlcv_4h.py
+++ b/get_ohlcv_4h.py
@@ -17,6 +17,9 @@ REQ_TIMESTAMPS = []
 MAX_REQS_PER_MIN = 79
 REQ_LOCK = threading.Lock()
 
+# API request limit
+LIMIT = 1500
+
 # 加载环境变量并校验
 load_dotenv()
 API_KEY = secret_get("CG_API_KEY")
@@ -110,7 +113,7 @@ def build_url(symbol: str, start_ts: int, end_ts: int) -> str:
         f"?exchange=Binance"
         f"&symbol={symbol}"
         f"&interval=4h"
-        f"&limit=1500"
+        f"&limit={LIMIT}"
         f"&start_time={start_ts}"
         f"&end_time={end_ts}"
     )
@@ -180,10 +183,10 @@ def process_symbol(symbol: str, end_ts: int, tz8, interval: int) -> tuple[int, i
         return 0, 0
 
     if latest is None:
-        start_ts = end_ts - interval * 4500
+        start_ts = end_ts - interval * LIMIT
     else:
         start_ts = latest + interval
-        min_start = end_ts - interval * 4500
+        min_start = end_ts - interval * LIMIT
         if start_ts < min_start:
             start_ts = min_start
 


### PR DESCRIPTION
## Summary
- parametrize download limit for OHLCV fetchers
- align historical start time with the limit in hourly and 4‑hour scripts

## Testing
- `python -m py_compile get_ohlcv_1h.py get_ohlcv_4h.py`

------
https://chatgpt.com/codex/tasks/task_e_68595e81e480832c97bf8e56ee5220f1