### PR TITLE
Fix OHLCV end timestamp

### DIFF
--- a/get_ohlcv_1h.py
+++ b/get_ohlcv_1h.py
@@ -174,7 +174,7 @@ ON CONFLICT(symbol, time) DO NOTHING;
 def process_symbol(symbol: str, end_ts: int, tz8, interval: int) -> tuple[int, int]:
     """处理单个交易对：下载并写入数据"""
     latest = get_symbol_latest_ts(symbol)
-    expected_last = end_ts - interval
+    expected_last = end_ts
     if latest is not None and latest >= expected_last:
         print(f"{symbol} 数据已是最新，跳过", flush=True)
         return 0, 0
@@ -208,7 +208,7 @@ def main() -> None:
     interval = 3600 * 1000
     now_ms = int(datetime.now(timezone.utc).timestamp() * 1000)
     # use the last completed hour as the end point
-    end_ts = (now_ms // interval) * interval - interval
+    end_ts = (now_ms // interval) * interval
 
     symbols = get_symbols_from_db()
     if not symbols:

--- a/get_ohlcv_4h.py
+++ b/get_ohlcv_4h.py
@@ -177,7 +177,7 @@ ON CONFLICT(symbol, time) DO NOTHING;
 def process_symbol(symbol: str, end_ts: int, tz8, interval: int) -> tuple[int, int]:
     """处理单个交易对：下载并写入数据"""
     latest = get_symbol_latest_ts(symbol)
-    expected_last = end_ts - interval
+    expected_last = end_ts
     if latest is not None and latest >= expected_last:
         print(f"{symbol} 数据已是最新，跳过", flush=True)
         return 0, 0
@@ -206,7 +206,7 @@ def main() -> None:
     interval = 4 * 3600 * 1000
     now_ms = int(datetime.now(timezone.utc).timestamp() * 1000)
     # last completed 4h period
-    end_ts = (now_ms // interval) * interval - interval
+    end_ts = (now_ms // interval) * interval
 
     symbols = get_symbols_from_db()
     if not symbols:


### PR DESCRIPTION
## Summary
- correct end_ts calculations for hourly and 4h OHLCV scripts
- adjust up-to-date check

## Testing
- `python -m py_compile get_ohlcv_1h.py get_ohlcv_4h.py`

------
https://chatgpt.com/codex/tasks/task_e_68598ade31b8832cb7ff707db4101007