### PR TITLE
Add table switcher to OHLCV page

### DIFF
--- a/app_pages/ohlcv.py
+++ b/app_pages/ohlcv.py
@@ -10,6 +10,15 @@ def render_ohlcv_page():
     instruments = fetch_instruments(engine_ohlcv)["symbol"].tolist()
     symbol = st.selectbox("选择交易对", instruments, key="ohlcv_sym")
 
+    table = st.selectbox(
+        "选择表",
+        (
+            "ohlcv_1h",
+            "ohlcv_4h",
+        ),
+        key="ohlcv_table",
+    )
+
     start_date = st.date_input(
         "开始日期", datetime.now() - timedelta(days=7), key="ohlcv_start_date"
     )
@@ -31,7 +40,7 @@ def render_ohlcv_page():
         start_ts = int(start_dt.timestamp() * 1000)
         end_ts = int(end_dt.timestamp() * 1000)
 
-        df = fetch_ohlcv(engine_ohlcv, symbol, start_ts, end_ts)
+        df = fetch_ohlcv(engine_ohlcv, symbol, start_ts, end_ts, table=table)
         if not df.empty:
             # 1. 将毫秒时间戳转换为 UTC+0 datetime 再转到 UTC+8
             df['datetime'] = (

--- a/queries.py
+++ b/queries.py
@@ -41,16 +41,41 @@ def fetch_instruments(engine):
 
 # OHLCV 表接口
 
-def fetch_ohlcv(engine, symbol, start_ts, end_ts):
+def fetch_ohlcv(engine, symbol, start_ts, end_ts, table="ohlcv_1h"):
+    """Fetch OHLCV records from the specified table.
+
+    Parameters
+    ----------
+    engine : sqlalchemy.engine.Engine
+        Database engine to execute the query against.
+    symbol : str
+        Trading pair symbol.
+    start_ts : int
+        Start timestamp in milliseconds.
+    end_ts : int
+        End timestamp in milliseconds.
+    table : str, optional
+        Table name to query, defaults to ``"ohlcv_1h"``.
+    """
+
+    if table not in {"ohlcv_1h", "ohlcv_4h"}:
+        raise ValueError("Invalid OHLCV table name")
+
+    sql = text(
+        f"SELECT * FROM {table} WHERE symbol=:symbol AND time BETWEEN :start AND :end ORDER BY time"
+    )
     return pd.read_sql(
-        text(
-            "SELECT * FROM ohlcv_1h WHERE symbol=:symbol AND time BETWEEN :start AND :end ORDER BY time"
-        ),
+        sql,
         engine,
         params={"symbol": symbol, "start": start_ts, "end": end_ts},
     )
 
 
-def fetch_distinct_ohlcv_symbols(engine) -> list[str]:
-    df = pd.read_sql("SELECT DISTINCT symbol FROM ohlcv_1h", engine)
+def fetch_distinct_ohlcv_symbols(engine, table="ohlcv_1h") -> list[str]:
+    """Return all distinct symbols from the specified OHLCV table."""
+
+    if table not in {"ohlcv_1h", "ohlcv_4h"}:
+        raise ValueError("Invalid OHLCV table name")
+
+    df = pd.read_sql(f"SELECT DISTINCT symbol FROM {table}", engine)
     return df["symbol"].tolist()


### PR DESCRIPTION
## Summary
- enable selection of `ohlcv_1h` or `ohlcv_4h` table when viewing OHLCV data
- update query helpers to accept a table name

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685a06af6b04832c8bb4ed8511fabf6b