### PR TITLE
Add strong asset cron script & fix quick range

### DIFF
--- a/tgbot/cron_example.txt
+++ b/tgbot/cron_example.txt
@@ -1,0 +1,3 @@
+# Run the strong asset notifier at 05 minutes past each hour
+# Adjust the path to the repository as needed
+5 * * * * /usr/bin/python3 /path/to/repo/tgbot/time_strong_asset.py >> /var/log/time_strong_asset.log 2>&1

--- a/tgbot/time_strong_asset.py
+++ b/tgbot/time_strong_asset.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Send the strongest assets over the last 4h to Telegram."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+import pandas as pd
+from sqlalchemy import text
+import pytz
+
+from strategies.strong_assets import compute_period_metrics
+from db import engine_ohlcv
+from monitor_bot import ascii_table, send_message
+from config import TZ_NAME
+
+
+def last_4h_range() -> tuple[int, int, str]:
+    """Return start/end timestamps in ms and a HH:MM-HH:MM label."""
+    tz = pytz.timezone(TZ_NAME)
+    now_ts = int(datetime.now(tz).timestamp())
+    end_dt = datetime.fromtimestamp(((now_ts // 3600) - 1) * 3600, tz)
+    start_dt = end_dt - timedelta(hours=3)
+    label = f"{start_dt.strftime('%H:%M')}-{end_dt.strftime('%H:%M')}"
+    return int(start_dt.timestamp() * 1000), int(end_dt.timestamp() * 1000), label
+
+
+def main() -> None:
+    start_ts, end_ts, label = last_4h_range()
+    with engine_ohlcv.begin() as conn:
+        symbols = [r[0] for r in conn.execute(text("SELECT DISTINCT symbol FROM ohlcv_1h"))]
+        label_map = {r[0]: r[1] for r in conn.execute(text("SELECT instrument_id, labels FROM instruments"))}
+
+    records = []
+    for sym in symbols:
+        try:
+            m = compute_period_metrics(sym, start_ts, end_ts)
+        except ValueError:
+            continue
+        m["symbol"] = sym
+        records.append(m)
+
+    if not records:
+        return
+
+    df = pd.DataFrame(records)
+    df["标签"] = df["symbol"].map(lambda s: "，".join(label_map.get(s, [])) if label_map.get(s) else "")
+    df["期间收益"] = (df["period_return"] * 100).map(lambda x: f"{x:.2f}%")
+    df = df.sort_values("period_return", ascending=False).reset_index(drop=True)
+    df["symbol"] = df["symbol"].str.replace("USDT", "")
+    df = df[["标签", "symbol", "期间收益"]]
+    df = df.rename(columns={"symbol": "代币名字"})
+
+    table = ascii_table(df)
+    header = f"最近4h（{label}）强势标的"
+    send_message(f"{header}\n```\n{table}\n```")
+
+
+if __name__ == "__main__":
+    main()

--- a/utils.py
+++ b/utils.py
@@ -102,9 +102,12 @@ def quick_range_buttons(
         # time to the most recent completed hour regardless of the
         # selected range length.
         now_ts = int(datetime.now(tz).timestamp())
-        end_ts = (now_ts // 3600) * 3600
+        # use the last completed hour as end time since each candle's
+        # timestamp marks the start of that hour
+        end_ts = ((now_ts // 3600) - 1) * 3600
         end = datetime.fromtimestamp(end_ts, tz)
-        start = end - timedelta(hours=hours)
+        # include ``hours`` candles ending at ``end`` (inclusive)
+        start = end - timedelta(hours=hours - 1)
 
         st.session_state[start_date_key] = start.date()
         st.session_state[start_time_key] = start.time().replace(second=0, microsecond=0)


### PR DESCRIPTION
## Summary
- adjust quick selection to use last completed hour
- add Telegram bot script for 4h strong asset notification
- provide crontab snippet for hourly execution

## Testing
- `python3 -m py_compile tgbot/time_strong_asset.py utils.py`


------
https://chatgpt.com/codex/tasks/task_e_685a428b66e0832c9ac420e57df3d864