### PR TITLE
Fix time_strong_asset output

### DIFF
--- a/tgbot/time_strong_asset.py
+++ b/tgbot/time_strong_asset.py
@@ -43,6 +43,7 @@ def main() -> None:
         records.append(m)
 
     if not records:
+        print("No data for the specified period")
         return
 
     df = pd.DataFrame(records)
@@ -55,6 +56,12 @@ def main() -> None:
 
     table = ascii_table(df)
     header = f"最近4h（{label}）强势标的"
+
+    # Print to console so manual runs have visible output
+    print(header)
+    print(table)
+
+    # Send to Telegram if credentials are configured
     send_message(f"{header}\n```\n{table}\n```")
 
 


### PR DESCRIPTION
## Summary
- print the strong asset table to the console
- show message when no data is available

## Testing
- `python -m py_compile tgbot/time_strong_asset.py`
- `python tgbot/time_strong_asset.py` *(fails: No module named 'pandas')*
- `pip install -q -r requirements.txt` *(fails: Could not find a version that satisfies the requirement streamlit>=1.0)*

------
https://chatgpt.com/codex/tasks/task_e_685a471123bc832c8b279a5db0cf2aaf