### PR TITLE
Fix strong asset message length

### DIFF
--- a/tgbot/time_strong_asset.py
+++ b/tgbot/time_strong_asset.py
@@ -50,6 +50,8 @@ def main() -> None:
     df["标签"] = df["symbol"].map(lambda s: "，".join(label_map.get(s, [])) if label_map.get(s) else "")
     df["期间收益"] = (df["period_return"] * 100).map(lambda x: f"{x:.2f}%")
     df = df.sort_values("period_return", ascending=False).reset_index(drop=True)
+    # Only keep the top 10 assets to avoid overly long Telegram messages
+    df = df.head(10)
     df["symbol"] = df["symbol"].str.replace("USDT", "")
     df = df[["标签", "symbol", "期间收益"]]
     df = df.rename(columns={"symbol": "代币名字"})


### PR DESCRIPTION
## Summary
- send only top 10 strong assets in `time_strong_asset.py` so Telegram message doesn't exceed length limits

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a493093fc832c9c5c902d5b83fb23