### PR TITLE
Update overview with telegram jobs

### DIFF
--- a/app_pages/overview.py
+++ b/app_pages/overview.py
@@ -1,5 +1,24 @@
 import streamlit as st
+from datetime import datetime, timedelta
+import pytz
+from streamlit_autorefresh import st_autorefresh
+
+from config import TZ_NAME
 
 def render_overview():
     st.title("Dashboard")
-    st.info("看板构建中")
+
+    # Auto refresh every hour at the 6 minute mark
+    tz = pytz.timezone(TZ_NAME)
+    now = datetime.now(tz)
+    refresh_time = now.replace(minute=6, second=0, microsecond=0)
+    if now >= refresh_time:
+        refresh_time += timedelta(hours=1)
+    interval_ms = int((refresh_time - now).total_seconds() * 1000)
+    st_autorefresh(interval=interval_ms, key="overview_refresh")
+
+    st.subheader("定时推送任务")
+    st.markdown(
+        "- **time_strong_asset.py**：每小时05分发送最近4小时强势标的信息\n"
+        "- **time_vol_alert.py**：每小时06分推送成交量异动提醒"
+    )


### PR DESCRIPTION
## Summary
- show cron info on dashboard
- add overview page auto-refresh every hour

## Testing
- `python -m py_compile app_pages/overview.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b87aa1c74832cb1e8d6a7c0eb2c92