### PR TITLE
Implement rotating strong asset slots

### DIFF
--- a/app_pages/overview.py
+++ b/app_pages/overview.py
@@ -6,8 +6,11 @@ import pandas as pd
 from pathlib import Path
 from utils import safe_rerun
 from config import TZ_NAME
-from tgbot.time_strong_asset import last_4h_range
 from tgbot.time_vol_alert import last_hour_label
+from sqlalchemy import text
+from result_cache import load_cached, save_cached
+from strategies.strong_assets import compute_period_metrics
+from db import engine_ohlcv
 
 CACHE_BASE = Path("/home/ubuntu/k2database/tgbot/data/cache")
 
@@ -27,11 +30,77 @@ def _read_latest(subdir: str) -> pd.DataFrame:
         return pd.DataFrame()
 
 
-def _latest_strong_assets() -> tuple[str, pd.DataFrame]:
-    """Return label and cached dataframe for the last 4h strong assets."""
-    _, _, label = last_4h_range()
-    df = _read_latest("overview_sa")
-    return label, df
+
+def _slot_range(now: datetime, start_h: int, end_h: int) -> tuple[int, int, str]:
+    """Return start/end timestamps and label for a time slot.
+
+    ``start_h`` and ``end_h`` are hour values in 24h format.  If the slot for
+    the current day has not finished yet, only completed hours are included.
+    When no data is available for today the same slot of the previous day is
+    used instead.
+    """
+    tz = pytz.timezone(TZ_NAME)
+    now = now.astimezone(tz)
+    start_today = now.replace(hour=start_h, minute=0, second=0, microsecond=0)
+    end_today = now.replace(hour=end_h, minute=0, second=0, microsecond=0)
+    last_hour = now.replace(minute=0, second=0, microsecond=0) - timedelta(hours=1)
+
+    slot_hours = end_h - start_h
+
+    if last_hour < start_today:
+        start_dt = start_today - timedelta(days=1)
+        end_dt = start_dt + timedelta(hours=slot_hours) - timedelta(hours=1)
+    else:
+        start_dt = start_today
+        end_dt = min(last_hour, end_today - timedelta(hours=1))
+        if end_dt < start_dt:
+            start_dt -= timedelta(days=1)
+            end_dt = start_dt + timedelta(hours=slot_hours) - timedelta(hours=1)
+
+    label = (
+        f"{start_dt.strftime('%Y.%m.%d %H:%M')}-"
+        f"{(end_dt + timedelta(hours=1)).strftime('%H:%M')}"
+    )
+    return int(start_dt.timestamp() * 1000), int(end_dt.timestamp() * 1000), label
+
+
+def _load_slot_df(start_ts: int, end_ts: int) -> pd.DataFrame:
+    """Load or compute strong assets for the given time range."""
+    params = {"start": start_ts, "end": end_ts}
+    cache_id, df = load_cached("overview_sa_slots", params)
+    if df is not None:
+        return df
+
+    with engine_ohlcv.begin() as conn:
+        symbols = [r[0] for r in conn.execute(text("SELECT DISTINCT symbol FROM ohlcv_1h"))]
+        label_map = {
+            r[0]: r[1] for r in conn.execute(text("SELECT instrument_id, labels FROM instruments"))
+        }
+
+    records = []
+    for sym in symbols:
+        try:
+            m = compute_period_metrics(sym, start_ts, end_ts)
+        except ValueError:
+            continue
+        m["symbol"] = sym
+        records.append(m)
+
+    if not records:
+        df = pd.DataFrame()
+    else:
+        df = pd.DataFrame(records)
+        df["标签"] = df["symbol"].map(
+            lambda s: "，".join(label_map.get(s, [])) if label_map.get(s) else ""
+        )
+        df["期间收益"] = (df["period_return"] * 100).map(lambda x: f"{x:.2f}%")
+        df = df.sort_values("period_return", ascending=False).reset_index(drop=True)
+        df = df.head(10)
+        df["symbol"] = df["symbol"].str.replace("USDT", "")
+        df = df[["标签", "symbol", "期间收益"]].rename(columns={"symbol": "代币名字"})
+
+    save_cached("overview_sa_slots", params, df)
+    return df
 
 
 def _latest_volume_alert() -> tuple[str, pd.DataFrame]:
@@ -63,10 +132,23 @@ def render_overview():
     interval = 1000 if time_left.total_seconds() <= 30 else 10_000
     st_autorefresh(interval=interval, key="overview_timer")
 
+    SLOT_INFO = [
+        (4, 8, "美股收盘强势标的"),
+        (8, 12, "亚盘时间强势标的"),
+        (16, 22, "美股盘前强势标的"),
+    ]
+
+    def _load_all_slots() -> list[tuple[str, pd.DataFrame]]:
+        results = []
+        for start_h, end_h, title in SLOT_INFO:
+            s_ts, e_ts, label = _slot_range(now, start_h, end_h)
+            df = _load_slot_df(s_ts, e_ts)
+            results.append((f"{label} {title}", df))
+        return results
+
     def manual_refresh() -> None:
         """Reload cached results and refresh the page."""
-        sa_label, st.session_state["sa_df"] = _latest_strong_assets()
-        st.session_state["sa_label"] = sa_label
+        st.session_state["sa_slots"] = _load_all_slots()
         vol_label, st.session_state["vol_df"] = _latest_volume_alert()
         st.session_state["vol_label"] = vol_label
         st.session_state["next_refresh_time"] = _next_refresh_time(datetime.now(tz))
@@ -82,23 +164,27 @@ def render_overview():
         st.button("↻", help="手动刷新", on_click=manual_refresh)
 
     if (
-        "sa_df" not in st.session_state
+        "sa_slots" not in st.session_state
         or "vol_df" not in st.session_state
         or refresh_due
     ):
-        sa_label, st.session_state["sa_df"] = _latest_strong_assets()
-        st.session_state["sa_label"] = sa_label
+        st.session_state["sa_slots"] = _load_all_slots()
         vol_label, st.session_state["vol_df"] = _latest_volume_alert()
         st.session_state["vol_label"] = vol_label
         st.session_state["next_refresh_time"] = _next_refresh_time(datetime.now(tz))
 
-    sa_label = st.session_state.get("sa_label", "")
+    if "sa_index" not in st.session_state:
+        st.session_state["sa_index"] = 0
+    elif refresh_due:
+        st.session_state["sa_index"] = (st.session_state["sa_index"] + 1) % len(SLOT_INFO)
+
     vol_label = st.session_state.get("vol_label", "")
 
     col1, col2 = st.columns(2)
     with col1:
-        st.markdown(f"**最近4h（{sa_label}）强势标的**")
-        st.dataframe(st.session_state.get("sa_df"), use_container_width=True)
+        sa_label, sa_df = st.session_state["sa_slots"][st.session_state["sa_index"]]
+        st.markdown(f"**{sa_label}**")
+        st.dataframe(sa_df, use_container_width=True)
     with col2:
         st.markdown(f"**{vol_label} 成交量异动 (24h均量)**")
         st.dataframe(st.session_state.get("vol_df"), use_container_width=True)


### PR DESCRIPTION
## Summary
- overhaul overview strong asset section to rotate between predefined time slots
- compute strong asset ranges dynamically with caching

## Testing
- `python -m py_compile app_pages/overview.py`

------
https://chatgpt.com/codex/tasks/task_e_685e4348b68c832c9e0841cbeb5b63ff